### PR TITLE
Add a github pages version, with search

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+    branches: [master]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - run: bin/publish
+      - run: git checkout -b gh-pages
+      - run: git config --global user.name "MoJ Github Action"
+      - run: git config --global user.email "platforms@digital.justice.gov.uk"
+      - run: git add index.html
+      - run: git commit -m "Publish latest changes"
+      - run: git push origin gh-pages --force

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,0 +1,5 @@
+# Information for developers
+
+This site uses a github action `.github/workflows/publish.yml` to take the rows of markdown table in `README.md` and combine them with the template file `template/index.html.erb` to create `index.html`.
+
+The `index.html` file is then force-pushed to the `gh-pages` branch of the repository. This is set as the branch to publish via GitHub Pages in the [repo settings](https://github.com/ministryofjustice/acronyms/settings)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ministry of Justice Acronyms
 
+## View the [published site here](https://ministryofjustice.github.io/acronyms/)
+
 This is a temporary replacement for the (currently defunct) "Big Book of Acronyms" web application.
 
 ## Contributing

--- a/bin/publish
+++ b/bin/publish
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+
+require "erb"
+
+Abbr = Struct.new(:abbreviation, :definition, :url, :info)
+
+SOURCE_FILE = "README.md"
+TEMPLATE = "template/index.html.erb"
+TARGET_FILE = "index.html"
+
+def abbreviations(file)
+  File.read(file)
+    .split("\n").grep(/^\|/)[2,9999999]  # table rows, minus header & separator
+    .map { |line| line.split("|").map { |str| str.strip } }  # convert to arrays of trimmed strings
+    .map { |arr| arr[1,4] } # discard extraneous "" from start & end of each array
+    .map { |arr| Abbr.new(*arr) } # convert to Abbr objects
+end
+
+list = abbreviations(SOURCE_FILE)
+
+warning = "
+  <!--
+
+    DO NOT EDIT THIS HTML FILE MANUALLY
+
+    This file is updated by the bin/publish script, via a github action.
+    Any changes you make will be lost on the next update.
+
+  -->
+  "
+
+updated_at = Time.now.strftime("%Y-%m-%d %H:%M")
+
+renderer = ERB.new(File.read(TEMPLATE))
+html = renderer.result(binding)
+File.write(TARGET_FILE, html)

--- a/template/index.html.erb
+++ b/template/index.html.erb
@@ -1,0 +1,105 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://unpkg.com/purecss@2.0.3/build/pure-min.css" integrity="sha384-cg6SkqEOCV1NbJoCu11+bm0NvBRc8IYLRGXkmNrqUBfTjmMYwNKPWBTIKyw9mHNJ" crossorigin="anonymous">
+    <style>
+      .content {
+        margin: 50px;
+      }
+
+      tr.hidden {
+        display: none;
+      }
+
+    </style>
+    <title>Ministry of Justice Acronyms</title>
+  </head>
+  <body>
+    <%= warning %>
+    <div class="content">
+
+      <h1>Ministry of Justice Acronyms<h1>
+
+      <h3>Last updated: <%= updated_at %></h3>
+
+      <h4>
+        Search:
+        <input type="text" id="searchField" />
+      </h4>
+
+      <p>
+        If you have a GitHub account, you can update this list by clicking
+        <a href="https://github.com/ministryofjustice/acronyms/edit/master/README.md">here.</a>
+      </p>
+
+      <table class="pure-table pure-table-horizontal" id="abbreviations">
+        <thead>
+          <tr>
+            <th>Abbreviation</th>
+            <th>Definition</th>
+            <th>URL</th>
+            <th>Info</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% list.each do |item| %>
+            <tr>
+              <td><%= item.abbreviation %></td>
+              <td><%= item.definition %></td>
+              <td>
+                <a href="<%= item.url %>">
+                  <%= item.url %>
+                </a>
+              </td>
+              <td><%= item.info %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </body>
+
+  <script>
+
+    var searchField = document.getElementById("searchField");
+
+    searchField.onkeyup = function () {
+      hideRowsWhichDontMatch(searchField.value);
+    }
+
+    function hideRowsWhichDontMatch(str) {
+      var search = str.toLowerCase();
+      var table = document.getElementById("abbreviations");
+
+      showAllRows(table);
+
+      for (var i = 1, row; row = table.rows[i]; i++) {
+        if (search !== "") {
+          // hide rows which don't match search
+          var abbreviation = row.cells[0].textContent;
+          var description = row.cells[1].textContent;
+
+          var hideRow = true;
+
+          if (abbreviation !== undefined && abbreviation.toLowerCase().match(search)) {
+            hideRow = false;
+          }
+
+          if (description !== undefined && description.toLowerCase().match(search)) {
+            hideRow = false;
+          }
+
+          if (hideRow) {
+            row.className = "hidden";
+          }
+        }
+      }
+    }
+
+    function showAllRows(table) {
+      for (var i = 1, row; row = table.rows[i]; i++) {
+        row.className = "";
+      }
+    }
+
+  </script>
+</html>


### PR DESCRIPTION
This is based on a request from Mark Stanley for a "user-friendlier" version of the acronyms site, which would allow users to easily search for acronyms.

This PR adds a minimal publishing process, based on github actions and github pages, to create an index.html which includes a javascript filtering function. Users can type a string into the search field, and the code will hide any table rows where neither the abbreviation nor the description match the search term (using a basic case-insensitive regexp match).

Once merged, the result will be exactly like this: https://digitalronin.github.io/acronyms/

That's the fork of this repo on which I developed the code, before raising this PR to apply the corresponding changes to the live site.