### PR TITLE
Focus the search field on page load

### DIFF
--- a/template/index.html.erb
+++ b/template/index.html.erb
@@ -23,7 +23,7 @@
 
       <h4>
         Search:
-        <input type="text" id="searchField" />
+        <input type="text" id="searchField" autofocus />
       </h4>
 
       <p>


### PR DESCRIPTION
This allows the user to just start typing to find the abbreviation
they're looking for, without having to move the mouse and click the
field first.

fixes #16