### PR TITLE
Add "Delius Data Dictionary" page

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,6 @@ jobs:
       - run: git checkout -b gh-pages
       - run: git config --global user.name "MoJ Github Action"
       - run: git config --global user.email "platforms@digital.justice.gov.uk"
-      - run: git add index.html
+      - run: git add *.html
       - run: git commit -m "Publish latest changes"
       - run: git push origin gh-pages --force

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a temporary replacement for the (currently defunct) "Big Book of Acronym
 
 ## Contributing
 
-If you have a github account, you can [click here](https://github.com/ministryofjustice/acronyms/edit/master/README.md) to edit this file.
+If you have a github account, you can [click here](https://github.com/ministryofjustice/acronyms/edit/main/README.md) to edit this file.
 
 A better mechanism to enable people without github accounts to suggest changes will hopefully be provided in due course.
 

--- a/bin/publish
+++ b/bin/publish
@@ -4,21 +4,29 @@ require "erb"
 
 Abbr = Struct.new(:abbreviation, :definition, :url, :info)
 
-SOURCE_FILE = "README.md"
-TEMPLATE = "template/index.html.erb"
-TARGET_FILE = "index.html"
+DeliusDataDictionaryEntry = Struct.new(
+  :category,
+  :field_name,
+  :description,
+  :variable_type,
+  :allowed_values,
+  :date_populated,
+  :example_field,
+  :missingness,
+  :comments
+)
 
-def abbreviations(file)
-  File.read(file)
+def get_data(markdown_file, num_columns, object_class)
+  File.read(markdown_file)
     .split("\n").grep(/^\|/)[2,9999999]  # table rows, minus header & separator
     .map { |line| line.split("|").map { |str| str.strip } }  # convert to arrays of trimmed strings
-    .map { |arr| arr[1,4] } # discard extraneous "" from start & end of each array
-    .map { |arr| Abbr.new(*arr) } # convert to Abbr objects
+    .map { |arr| arr[1,num_columns] } # discard extraneous "" from start & end of each array
+    .map { |arr| object_class.new(*arr) } # convert to objects
 end
 
-list = abbreviations(SOURCE_FILE)
-
-warning = "
+def render_html(list, template, target_file)
+  updated_at = Time.now.strftime("%Y-%m-%d %H:%M")
+  warning = "
   <!--
 
     DO NOT EDIT THIS HTML FILE MANUALLY
@@ -28,9 +36,21 @@ warning = "
 
   -->
   "
+  renderer = ERB.new(File.read(template))
+  html = renderer.result(binding)
+  File.write(target_file, html)
+end
 
-updated_at = Time.now.strftime("%Y-%m-%d %H:%M")
+def output_section_html(section, num_columns, object_class)
+  source = "#{section}.md"
+  template = "template/#{section}.html.erb"
+  target_file = "#{section}.html"
+  list = get_data(source, num_columns, object_class)
+  render_html(list, template, target_file)
+end
 
-renderer = ERB.new(File.read(TEMPLATE))
-html = renderer.result(binding)
-File.write(TARGET_FILE, html)
+# Main acronyms page
+list = get_data("README.md", 4, Abbr)
+render_html(list, "template/index.html.erb", "index.html")
+
+output_section_html("delius-data-dictionary", 9, DeliusDataDictionaryEntry)

--- a/delius-data-dictionary.md
+++ b/delius-data-dictionary.md
@@ -1,0 +1,13 @@
+# Delius Data Dictionary
+
+## View the [published site here](https://ministryofjustice.github.io/acronyms/delius-data-dictionary.html)
+
+## Contributing
+
+If you have a github account, you can [click here](https://github.com/ministryofjustice/acronyms/edit/main/delius-data-dictionary.md) to edit this file.
+
+| Category | Field Name | Description | Variable Type | Allowed Values | Date Populated | Example Field | Missingness | Comments |
+|-|-|-|-|-|-|-|-|-|
+| Whatever | WHATEVER_FLD | It's a thing | String | Foo, Bar, Baz | 2020-10-28 | Wheeee! | Purple | This is fine |
+| Height | HEIGHT | How tall you are. | Integer (cms) | 0-300 | 2020-10-18 | 172 | | |
+| Weight | WEIGHT | How heavy you are. | Integer (kgs) | 0-300 | 2020-10-28 | 85 | | Could lose a few kilos. |

--- a/template/delius-data-dictionary.html.erb
+++ b/template/delius-data-dictionary.html.erb
@@ -1,0 +1,116 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="https://unpkg.com/purecss@2.0.3/build/pure-min.css" integrity="sha384-cg6SkqEOCV1NbJoCu11+bm0NvBRc8IYLRGXkmNrqUBfTjmMYwNKPWBTIKyw9mHNJ" crossorigin="anonymous">
+    <style>
+      .content {
+        margin: 50px;
+      }
+
+      tr.hidden {
+        display: none;
+      }
+
+    </style>
+    <title>Delius Data Dictionary</title>
+  </head>
+  <body>
+    <%= warning %>
+    <div class="content">
+
+      <h1>Delius Data Dictionary<h1>
+
+      <h3>Last updated: <%= updated_at %></h3>
+
+      <h4>
+        Search:
+        <input type="text" id="searchField" autofocus />
+      </h4>
+
+      <p>
+        If you have a GitHub account, you can update this list by clicking
+        <a href="https://github.com/ministryofjustice/acronyms/edit/main/delius-data-dictionary.md">here.</a>
+      </p>
+
+      <table class="pure-table pure-table-horizontal" id="abbreviations">
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Field Name</th>
+            <th>Description</th>
+            <th>Variable Type</th>
+            <th>Allowed Values</th>
+            <th>Date Populated</th>
+            <th>Example Field</th>
+            <th>Missingness</th>
+            <th>Comments</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% list.each do |item| %>
+            <tr>
+              <td><%= item.category %></td>
+              <td><%= item.field_name %></td>
+              <td><%= item.description %></td>
+              <td><%= item.variable_type %></td>
+              <td><%= item.allowed_values %></td>
+              <td><%= item.date_populated %></td>
+              <td><%= item.example_field %></td>
+              <td><%= item.missingness %></td>
+              <td><%= item.comments %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </body>
+
+  <script>
+
+    var searchField = document.getElementById("searchField");
+
+    searchField.onkeyup = function () {
+      hideRowsWhichDontMatch(searchField.value);
+    }
+
+    function hideRowsWhichDontMatch(str) {
+      var search = str.toLowerCase();
+      var table = document.getElementById("abbreviations");
+
+      showAllRows(table);
+
+      for (var i = 1, row; row = table.rows[i]; i++) {
+        if (search !== "") {
+          // hide rows which don't match search
+          var category = row.cells[0].textContent;
+          var field_name = row.cells[1].textContent;
+          var description = row.cells[2].textContent;
+
+          var hideRow = true;
+
+          if (category !== undefined && category.toLowerCase().match(search)) {
+            hideRow = false;
+          }
+
+          if (field_name !== undefined && field_name.toLowerCase().match(search)) {
+            hideRow = false;
+          }
+
+          if (description !== undefined && description.toLowerCase().match(search)) {
+            hideRow = false;
+          }
+
+          if (hideRow) {
+            row.className = "hidden";
+          }
+        }
+      }
+    }
+
+    function showAllRows(table) {
+      for (var i = 1, row; row = table.rows[i]; i++) {
+        row.className = "";
+      }
+    }
+
+  </script>
+</html>

--- a/template/index.html.erb
+++ b/template/index.html.erb
@@ -28,7 +28,7 @@
 
       <p>
         If you have a GitHub account, you can update this list by clicking
-        <a href="https://github.com/ministryofjustice/acronyms/edit/master/README.md">here.</a>
+        <a href="https://github.com/ministryofjustice/acronyms/edit/main/README.md">here.</a>
       </p>
 
       <table class="pure-table pure-table-horizontal" id="abbreviations">


### PR DESCRIPTION
Add "Delius Data Dictionary" page to the site

This is an MVP for a future project which will
probably spin off into its own repository, in due
course.

The main changes are in the `bin/publish` script,
which can now cope with two different source
`*.md` files, with different numbers of columns,
and column headings.
