### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,7 +1102,6 @@ into the community. There are four types of temporary release licence. |"
 | TAD | Technical Architecture Document | | |
 | TAD | Tender Assessment Database | | Used by LAA to record assessment of contract tender responses. |
 | TAFKADSD | The Artists Formerly Known as the Digital Services Division | | Subsequently known as MOJ Digital Services. Currently known as MOJ Digital. |
-| TAP | Temporary Approved Premises | | Locaitons outside of prisons where prisons may be staying - for example a hospital |
 | TBC | To Be Confirmed | | |
 | TBD | To Be Decided or Defined | | |
 | TC | Therapeutic Community | | |


### PR DESCRIPTION
Proposing that this entry is deleted because it appears to be inaccurate:
- Temporary Approved Premises is not a term used within the Approved Premises space
- The description appears to refer to Temporarily Absent Prisoner  (which is used as a location as well as a person)

This is being addressed in the HMPPS style guide and we can feed in a new entry as required.  | | Locaitons outside of prisons where prisons may be staying - for example a hospital |